### PR TITLE
Settings: Animate pin/pattern fragment only if available

### DIFF
--- a/src/com/android/settings/ConfirmDeviceCredentialBaseActivity.java
+++ b/src/com/android/settings/ConfirmDeviceCredentialBaseActivity.java
@@ -92,11 +92,17 @@ public abstract class ConfirmDeviceCredentialBaseActivity extends SettingsActivi
     }
 
     public void prepareEnterAnimation() {
-        getFragment().prepareEnterAnimation();
+        final ConfirmDeviceCredentialBaseFragment f = getFragment();
+        if (f != null) {
+            f.prepareEnterAnimation();
+        }
     }
 
     public void startEnterAnimation() {
-        getFragment().startEnterAnimation();
+        final ConfirmDeviceCredentialBaseFragment f = getFragment();
+        if (f != null) {
+            f.startEnterAnimation();
+        }
     }
 
     /**


### PR DESCRIPTION
To prevent NPE, check if the PIN/Pattern/Password confirmation
fragment is available before performing animation

Change-Id: I4ae78569f953daa6696e96c8318a0c059aaf3502
TICKET: HAM-1397